### PR TITLE
[BUG] Add support for Thunk 2.x series.

### DIFF
--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -1,3 +1,6 @@
 import thunk from 'npm:redux-thunk';
 
+// Thunk 2.x exports on a default key.
+const resolvedThunk = thunk.__esModule ? thunk.default : thunk;
+
 export default [thunk];


### PR DESCRIPTION
Thunk 2.x now requires looking at the default key when using CommonJS
imports (which is used by ember-browserify):
https://github.com/gaearon/redux-thunk/releases/tag/v2.0.0

When using Thunk 2.0.1, this is the error I saw as a result:
```
applyMiddleware.js:48 Uncaught TypeError: middleware is not a function
```