### PR TITLE
Create default blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@
 ## Installation
 
 ```
-npm install ember-browserify -D
-npm install redux@3 -D
-npm install redux-thunk@2 -D
-npm install ember-redux -D
+ember install ember-redux
 ```
 
 ## Documentation

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-redux/index.js
+++ b/blueprints/ember-redux/index.js
@@ -1,0 +1,18 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Installation blueprint for ember-redux',
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addAddonsToProject({
+      packages: [
+        {name: 'ember-browserify', target: '^1.1.11'},
+      ]
+    }).then(function() {
+      return this.addPackagesToProject([
+        {name: 'redux', target: '^3.5.2'},
+        {name: 'redux-thunk', target: '^2.1.0'}
+      ]);
+    }.bind(this));
+  }
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.0",
     "broccoli-asset-rev": "^2.2.0",
+    "ember-browserify": "^1.1.11",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
@@ -42,7 +43,8 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
     "ember-try": "0.1.3",
-    "ember-browserify": "^1.1.8"
+    "redux": "^3.5.2",
+    "redux-thunk": "^2.1.0"
   },
   "keywords": [
     "ember-addon",
@@ -52,9 +54,7 @@
     "redux"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
-    "redux": "^3.4.0",
-    "redux-thunk": "^2.0.1"
+    "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This enables a one-line install of ember-redux

TEST WITH:

```
ember install "ember-redux@dustinfarris/ember-redux#c2d0055"
```

CHANGES:

- Create default blueprint which adds dependencies to user's own package.json
- Move internal dependencies to devDependencies