### PR TITLE
17 - fixed arguments like transition not being passed into the route hook

### DIFF
--- a/addon/route.js
+++ b/addon/route.js
@@ -9,8 +9,9 @@ var route = function(funcs) {
                 var redux = this.get('redux');
                 var route = this;
                 Object.keys(funcs).forEach(function(func) {
-                    route[func] = function(args) {
-                        return funcs[func](redux.dispatch.bind(redux), args);
+                    route[func] = function(...args) {
+                        args.unshift(redux.dispatch.bind(redux));
+                        return funcs[func].apply(route, args);
                     };
                 });
                 this._super(...arguments);

--- a/tests/acceptance/route-hooks-test.js
+++ b/tests/acceptance/route-hooks-test.js
@@ -1,0 +1,14 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | route hooks');
+
+test('route hooks such as afterModel should have all its params be accessible in a connect', function(assert) {
+  visit('/items');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/items');
+
+    assert.equal(find('#after-model-transition').text(), 'ok');
+  });
+});

--- a/tests/dummy/app/components/item-list/component.js
+++ b/tests/dummy/app/components/item-list/component.js
@@ -4,12 +4,14 @@ import connect from 'ember-redux/components/connect';
 
 var stateToComputed = (state) => {
   return {
-    items: state.items.all
+    items: state.items.all,
+    transitionMsg: state.models.transition
   };
 };
 
 var ItemListComponent = Ember.Component.extend({
   layout: hbs`
+    <div id="after-model-transition">{{transitionMsg}}</div>
     {{#each items as |item|}}
       <div class="item-name">{{item.name}}</div>
       {{#link-to 'items.detail' item.id class='item-detail-link'}}details{{/link-to}}

--- a/tests/dummy/app/items/route.js
+++ b/tests/dummy/app/items/route.js
@@ -6,6 +6,13 @@ var model = (dispatch) => {
     return ajax('/api/items', 'GET').then(response => dispatch({type: 'DESERIALIZE_ITEMS', response: response}));
 };
 
+
+function afterModel(dispatch, model, transition) {
+  if (Ember.isPresent(transition)) {
+    dispatch({type: 'AFTER_MODEL', transition: 'ok'});
+  }
+}
+
 var ItemsRoute = Ember.Route.extend();
 
-export default route({model})(ItemsRoute);
+export default route({model, afterModel})(ItemsRoute);

--- a/tests/dummy/app/reducers/index.js
+++ b/tests/dummy/app/reducers/index.js
@@ -4,6 +4,7 @@ import all from 'dummy/reducers/all';
 import users from 'dummy/reducers/users';
 import roles from 'dummy/reducers/roles';
 import items from 'dummy/reducers/items';
+import models from 'dummy/reducers/models';
 
 export default {
     low: low,
@@ -11,5 +12,6 @@ export default {
     all: all,
     users: users,
     roles: roles,
+    models: models,
     items: items
 };

--- a/tests/dummy/app/reducers/models.js
+++ b/tests/dummy/app/reducers/models.js
@@ -1,0 +1,12 @@
+const initialState = {
+    transition: 'notOk',
+};
+
+export default ((state=initialState, action) => { // jshint ignore:line
+    if (action.type === 'AFTER_MODEL') {
+        return Object.assign({}, state, {
+            transition: action.transition
+        });
+    }
+    return state;
+});


### PR DESCRIPTION
Reference
===
https://github.com/toranb/ember-redux/issues/17#issuecomment-240909216

Changes
===
* properly exploded input arguments and now using apply to call them in `addon/route.js`
* added an acceptance-test for route-hooks
* modified the item-list component and items route to accomodate for the afterModel test
* added a reducer to handle `AFTER_MODEL`

Unrelated Note
===
I was looking at the `addon/components/connect.js:41` when I came across this:

```javascript
                    this.unsubscribe = redux.subscribe(() => {
                        props.forEach(function(name) {
                            component.notifyPropertyChange(name);
                        });
                    });
``` 
And it looks like each time an action is sent to redux, we tell ember that the property changed even if the property didn't actually change... is this ok? I mean, granted I'm making a lot of assumptions without any first-hand experience, but presumably, in a big app where actions are fired all the time, ember's going to have to be really busy all the time with updating all the computed properties everywhere on every action. Do you ever have any troubles with this in your applications?