### PR TITLE
Add reducer blueprints

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@
 bower.json
 ember-cli-build.js
 testem.js
+node-tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,4 @@ install:
 
 script:
   - ember try $EMBER_TRY_SCENARIO test
+  - npm run-script test:blueprints

--- a/blueprints/ember-redux/files/__root__/reducers/index.js
+++ b/blueprints/ember-redux/files/__root__/reducers/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/blueprints/reducer-test/files/tests/unit/reducers/__test__.js
+++ b/blueprints/reducer-test/files/tests/unit/reducers/__test__.js
@@ -1,0 +1,12 @@
+import reducer from '<%= dasherizedModulePrefix %>/reducers/<%= dasherizedModuleName %>';
+import { module, test } from 'qunit';
+
+module('<%= friendlyTestName %>');
+
+test('initial state', function(assert) {
+  assert.expect(1);
+
+  assert.deepEqual(reducer(undefined, {}),
+    {}, //replace with actual value
+  '<%= camelizedModuleName %> reducer returns the correct initial state');
+});

--- a/blueprints/reducer-test/index.js
+++ b/blueprints/reducer-test/index.js
@@ -1,0 +1,15 @@
+/*jshint node:true*/
+
+var stringUtils = require('ember-cli-string-utils');
+var testInfo    = require('ember-cli-test-info');
+
+module.exports = {
+  description: 'Generates a reducer test',
+
+  locals: function(options) {
+    return {
+      friendlyTestName: testInfo.name(options.entity.name, 'Unit', 'Reducer'),
+      dasherizedModulePrefix: stringUtils.dasherize(options.project.config().modulePrefix)
+    };
+  }
+};

--- a/blueprints/reducer/files/app/reducers/__name__.js
+++ b/blueprints/reducer/files/app/reducers/__name__.js
@@ -1,0 +1,9 @@
+const initialState = {}; //replace with actual value
+
+export default ((state=initialState, action) => { // jshint ignore:line
+  switch (action.type) {
+    //handle actions
+    default:
+      return state;
+  }
+});

--- a/blueprints/reducer/index.js
+++ b/blueprints/reducer/index.js
@@ -1,0 +1,143 @@
+/*jshint node:true*/
+
+var fs       = require('fs');
+var EOL      = require('os').EOL;
+var recast   = require('recast');
+var builders = require('recast').types.builders;
+var chalk    = require('chalk');
+
+module.exports = {
+  description: 'Generates a reducer',
+
+  reducerIndexPath: 'app/reducers/index.js',
+
+  updateReducerIndex: function(updateAst) {
+    var file;
+
+    try {
+      file = fs.readFileSync(this.reducerIndexPath, 'utf8');
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+
+      var error = new Error( 'Cannot find ' + this.reducerIndexPath +
+        ' Try running: ember generate ember-redux default');
+
+      this.ui.writeError(error);
+      return;
+    }
+
+    this.ui.writeLine('updating ' + this.reducerIndexPath);
+    var ast  = recast.parse(file);
+    updateAst(ast);
+
+    var code = recast.print(ast).code;
+    fs.writeFileSync(this.reducerIndexPath, code);
+  },
+
+  afterInstall: function(options) {
+    var reducerName = options.entity.name;
+
+    this.updateReducerIndex(function(ast) {
+      insertImport(reducerName, ast);
+      insertExportProp(reducerName, ast);
+      this._writeStatusToUI(chalk.green, 'add', reducerName);
+    }.bind(this));
+  },
+
+  afterUninstall: function(options) {
+    var reducerName = options.entity.name;
+
+    this.updateReducerIndex(function(ast) {
+      removeImport(reducerName, ast);
+      removeExportProp(reducerName, ast);
+      this._writeStatusToUI(chalk.red, 'remove', reducerName);
+    }.bind(this));
+  }
+};
+
+function insertImport(name, ast) {
+  var imports     = findImports(ast);
+  var foundImport = findImport(name, imports);
+
+  if(!foundImport) {
+    var newImport = builders.importDeclaration(
+      [ builders.importDefaultSpecifier(builders.identifier(name)) ],
+      builders.literal('./' + name));
+
+      ast.program.body.splice(imports.length, 0, newImport);
+  }
+}
+
+function removeImport(name, ast) {
+  var imports     = findImports(ast);
+  var foundImport = findImport(name, imports);
+
+  if(foundImport) {
+    ast.program.body.splice(foundImport.name, 1);
+  }
+}
+
+function findImports(ast) {
+  var imports = [];
+
+  recast.visit(ast, {
+    visitImportDeclaration: function(path) {
+      imports.push(path);
+      this.traverse(path);
+    }
+  });
+  return imports;
+}
+
+function findImport(name, imports) {
+  var foundPath;
+
+  imports.forEach(function(path) {
+    var importName = path.node.specifiers[0].local.name;
+    if(importName === name) {
+      foundPath = path;
+    }
+  });
+  return foundPath;
+}
+
+function insertExportProp(name, ast) {
+  var properties = getExportProperties(ast);
+  var idx        = findExportProperty(name, properties);
+
+  if(idx === undefined) {
+    properties.push(builders.identifier(name));
+  }
+}
+
+function removeExportProp(name, ast) {
+  var properties = getExportProperties(ast);
+  var idx        = findExportProperty(name, properties);
+
+  if(idx !== undefined) {
+    properties.splice(idx, 1);
+  }
+}
+
+function getExportProperties(ast) {
+  var properties;
+
+  recast.visit(ast, {
+    visitExportDefaultDeclaration: function(path) {
+      properties = path.node.declaration.properties;
+      return false;
+    }
+  });
+  return properties;
+}
+
+function findExportProperty(property, properties) {
+  var propertyIdx;
+
+  properties.forEach(function(prop, idx) {
+    if(prop.key.name === property) {
+      propertyIdx = idx;
+    }
+  });
+  return propertyIdx;
+}

--- a/node-tests/.babelrc
+++ b/node-tests/.babelrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-es2015-arrow-functions",
+    "transform-es2015-shorthand-properties"
+  ]
+}

--- a/node-tests/.jshintrc
+++ b/node-tests/.jshintrc
@@ -1,0 +1,9 @@
+{
+  "predef": [
+    "describe",
+    "it"
+  ],
+  "strict": true,
+  "node": true,
+  "esnext": true
+}

--- a/node-tests/blueprints/helpers/strip-margin.js
+++ b/node-tests/blueprints/helpers/strip-margin.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function(str) {
+  return str[0].split('\n')
+    .map(line => line.replace(/^\s*\|/, ''))
+    .join('\n');
+};

--- a/node-tests/blueprints/reducer-test-test.js
+++ b/node-tests/blueprints/reducer-test-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var blueprintHelpers     = require('ember-cli-blueprint-test-helpers/helpers');
+var setupTestHooks       = blueprintHelpers.setupTestHooks;
+var emberNew             = blueprintHelpers.emberNew;
+var emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
+var expect               = require('ember-cli-blueprint-test-helpers/chai').expect;
+var stripMargin          = require('./helpers/strip-margin');
+
+const TEST_FILE_PATH = 'tests/unit/reducers/foo-test.js';
+
+describe('Acceptance: ember generate and destroy reducer-test', function() {
+
+  setupTestHooks(this);
+
+  it('reducer-test', function() {
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(['reducer-test', 'foo'], (file) => {
+        expect(file(TEST_FILE_PATH)).to.equal(
+          stripMargin`|import reducer from 'my-app/reducers/foo';
+                      |import { module, test } from 'qunit';
+                      |
+                      |module('Unit | Reducer | foo');
+                      |
+                      |test('initial state', function(assert) {
+                      |  assert.expect(1);
+                      |
+                      |  assert.deepEqual(reducer(undefined, {}),
+                      |    {}, //replace with actual value
+                      |  'foo reducer returns the correct initial state');
+                      |});\n`
+          );
+    }));
+  });
+});

--- a/node-tests/blueprints/reducer-test.js
+++ b/node-tests/blueprints/reducer-test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers');
+var emberNew         = blueprintHelpers.emberNew;
+var emberDestroy     = blueprintHelpers.emberDestroy;
+var emberGenerate    = blueprintHelpers.emberGenerate;
+var setupTestHooks   = blueprintHelpers.setupTestHooks;
+var expect           = require('ember-cli-blueprint-test-helpers/chai').expect;
+var file             = require('ember-cli-blueprint-test-helpers/chai').file;
+var stripMargin      = require('./helpers/strip-margin');
+var fs               = require('fs');
+
+const REDUCER_INDEX_PATH = 'app/reducers/index.js';
+
+describe('Acceptance: ember generate and destroy reducer', function() {
+
+  setupTestHooks(this);
+
+  it('reducer', function() {
+
+    return emberNew()
+      .then(() => {
+          //TODO replace this step with default blueprint once issue fixed
+          //https://github.com/ember-cli/ember-cli-internal-test-helpers/issues/22
+          fs.mkdirSync('app/reducers');
+          fs.writeFileSync(REDUCER_INDEX_PATH,
+            stripMargin`|export default {};
+                        |\n`
+          );
+      })
+      .then(() => emberGenerate((['reducer', 'foo'])))
+      .then(() => emberGenerate((['reducer', 'foo']))) //test duplicate
+      .then(() => {
+          /* jshint expr:true */
+          expect(file('app/reducers/foo.js')).to.exist;
+          /* jshint expr:false */
+          expect(file(REDUCER_INDEX_PATH)).to.equal(
+            stripMargin`|import foo from "./foo";
+                        |export default {
+                        |  foo
+                        |};
+                        |\n`
+          );
+      })
+      .then(() => emberGenerate((['reducer', 'bar'])))
+      .then(() => {
+          /* jshint expr:true */
+          expect(file('app/reducers/bar.js')).to.exist;
+          /* jshint expr:false */
+          expect(file(REDUCER_INDEX_PATH)).to.equal(
+            stripMargin`|import foo from "./foo";
+                        |import bar from "./bar";
+                        |export default {
+                        |  foo,
+                        |  bar
+                        |};
+                        |\n`
+          );
+      })
+      .then(() => emberDestroy((['reducer', 'foo'])))
+      .then(() => emberDestroy((['reducer', 'foo']))) //test duplicate
+      .then(() => {
+          expect(file(REDUCER_INDEX_PATH)).to.equal(
+            stripMargin`|import bar from "./bar";
+                        |export default {
+                        |  bar
+                        |};
+                        |\n`
+          );
+      })
+      .then(() => emberDestroy((['reducer', 'bar'])))
+      .then(() => {
+          expect(file(REDUCER_INDEX_PATH)).to.equal(
+            stripMargin`|export default {};
+                        |\n`
+          );
+      });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,15 +9,16 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:testall",
+    "test:blueprints": "mocha node-tests --recursive --require babel-register"
   },
   "homepage": "https://github.com/toranb/ember-redux",
   "bugs": {
-      "url": "https://github.com/toranb/ember-redux/issues"
+    "url": "https://github.com/toranb/ember-redux/issues"
   },
   "repository": {
-      "type": "git",
-      "url": "https://github.com/toranb/ember-redux"
+    "type": "git",
+    "url": "https://github.com/toranb/ember-redux"
   },
   "engines": {
     "node": ">= 0.12.0"
@@ -25,12 +26,14 @@
   "author": "Toran Billups toranb@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "ember-cli": "2.4.2",
-    "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.0",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
+    "babel-register": "^6.11.6",
     "broccoli-asset-rev": "^2.2.0",
     "ember-browserify": "^1.1.11",
+    "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-blueprint-test-helpers": "^0.13.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -42,7 +45,10 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
+    "ember-resolver": "^2.0.3",
     "ember-try": "0.1.3",
+    "loader.js": "^4.0.0",
+    "mocha": "^2.5.3",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"
   },
@@ -54,7 +60,11 @@
     "redux"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "chalk": "^1.1.1",
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-string-utils": "^1.0.0",
+    "ember-cli-test-info": "^1.0.0",
+    "recast": "^0.11.12"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This adds blueprints to help manage reducers.

Create `app/reducers/index.js` on addon install:
```
➜  ember-redux-todomvc git:(master) ✗ ember generate ember-redux default
installing ember-redux
  create app/reducers/index.js  
```

Create a new reducer, its test, and update `app/reducers/index.js` :
```
➜  ember-redux-todomvc git:(master) ✗ ember generate reducer count
installing reducer
  create app/reducers/count.js
updating app/reducers/index.js
  add count
installing reducer-test
  create tests/unit/reducers/count-test.js
```

Remove a reducer, its test, and update `app/reducers/index.js`:
```
➜  ember-redux-todomvc git:(master) ✗ ember destroy reducer count
uninstalling reducer
  remove app/reducers/count.js
updating app/reducers/index.js
  remove count
uninstalling reducer-test
  remove tests/unit/reducers/count-test.js
```