### PR TITLE
Only re-render when truly required

### DIFF
--- a/addon/-private/equal.js
+++ b/addon/-private/equal.js
@@ -1,0 +1,25 @@
+// https://github.com/reactjs/react-redux/blob/master/src/utils/shallowEqual.js
+
+export default function shallowEqual(objA, objB) {
+    if (objA === objB) {
+        return true;
+    }
+
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+        return false;
+    }
+
+    // Test for A's keys different from B.
+    const hasOwn = Object.prototype.hasOwnProperty;
+    for (let i = 0; i < keysA.length; i++) {
+        if (!hasOwn.call(objB, keysA[i]) ||
+            objA[keysA[i]] !== objB[keysA[i]]) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/tests/acceptance/rerender-test.js
+++ b/tests/acceptance/rerender-test.js
@@ -1,0 +1,135 @@
+import Ember from 'ember';
+import { test, module } from 'qunit';
+import startApp from '../helpers/start-app';
+
+var application, oneUpdated = 0, twoUpdated = 0, fourUpdated = 0, fiveUpdated = 0;
+
+module('Acceptance | rerender test', {
+    beforeEach() {
+        application = startApp();
+    },
+    afterEach() {
+        Ember.run(application, 'destroy');
+    }
+});
+
+test('should only rerender when connected component is listening for each state used to compute', function(assert) {
+    ajax('/api/lists', 'GET', 200, [{id: 1, name: 'one', reviews: [{rating: 5}, {rating: 5}]}, {id: 2, name: 'two', reviews: [{rating: 3}, {rating: 1}]}]);
+    visit('/lists');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 2);
+        assert.equal(find('.list-item-one .item-rating').length, 4);
+        assert.equal(find('.list-item-two .item-name').length, 2);
+        assert.equal(find('.list-item-two .item-rating').length, 4);
+        assert.equal(find('.list-item-three .item-name').length, 2);
+        assert.equal(find('.list-item-three .item-rating').length, 4);
+        assert.equal(find('.unrelated-one').text(), '');
+        assert.equal(find('.random-one').text(), '');
+    });
+    andThen(() => {
+        var componentOne = application.__container__.lookup('component:list-one');
+        var componentTwo = application.__container__.lookup('component:list-two');
+        var componentFour = application.__container__.lookup('component:unrelated-one');
+        var componentFive = application.__container__.lookup('component:random-one');
+        var original = componentOne.updateProps;
+        componentOne.updateProps = function() {
+            oneUpdated = oneUpdated + 1;
+            return original.apply(this, arguments);
+        };
+        componentTwo.updateProps = function() {
+            twoUpdated = twoUpdated + 1;
+            return original.apply(this, arguments);
+        };
+        componentFour.updateProps = function() {
+            fourUpdated = fourUpdated + 1;
+            return original.apply(this, arguments);
+        };
+        componentFive.updateProps = function() {
+            fiveUpdated = fiveUpdated + 1;
+            return original.apply(this, arguments);
+        };
+    });
+    click('.filter-list:eq(0)');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 1);
+        assert.equal(find('.list-item-one .item-rating').length, 2);
+        assert.equal(find('.list-item-two .item-name').length, 1);
+        assert.equal(find('.list-item-two .item-rating').length, 2);
+        assert.equal(find('.list-item-three .item-name').length, 1);
+        assert.equal(find('.list-item-three .item-rating').length, 2);
+        assert.equal(find('.unrelated-one').text(), '');
+        assert.equal(find('.random-one').text(), '');
+    });
+    ajax('/api/lists', 'GET', 200, [{id: 1, name: 'one', reviews: [{rating: 5}, {rating: 5}, {rating: 1}]}, {id: 2, name: 'two', reviews: [{rating: 3}, {rating: 1}]}]);
+    click('.refresh-list:eq(0)');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 0);
+        assert.equal(find('.list-item-two .item-name').length, 0);
+        assert.equal(find('.list-item-three .item-name').length, 0);
+        assert.equal(find('.unrelated-one').text(), '');
+        assert.equal(find('.random-one').text(), '');
+    });
+    click('.filter-list:eq(1)');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 2);
+        assert.equal(find('.list-item-one .item-rating').length, 5);
+        assert.equal(find('.list-item-one .item-rating:eq(2)').text(), '1');
+        assert.equal(find('.list-item-two .item-name').length, 2);
+        assert.equal(find('.list-item-two .item-rating').length, 5);
+        assert.equal(find('.list-item-two .item-rating:eq(2)').text(), '1');
+        assert.equal(find('.list-item-three .item-name').length, 2);
+        assert.equal(find('.list-item-three .item-rating').length, 5);
+        assert.equal(find('.unrelated-one').text(), '');
+        assert.equal(find('.random-one').text(), '');
+    });
+    click('.unrelated-change:eq(0)');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 2);
+        assert.equal(find('.list-item-one .item-rating').length, 5);
+        assert.equal(find('.list-item-one .item-rating:eq(2)').text(), '1');
+        assert.equal(find('.list-item-two .item-name').length, 2);
+        assert.equal(find('.list-item-two .item-rating').length, 5);
+        assert.equal(find('.list-item-two .item-rating:eq(2)').text(), '1');
+        assert.equal(find('.list-item-three .item-name').length, 2);
+        assert.equal(find('.list-item-three .item-rating').length, 5);
+        assert.notEqual(find('.unrelated-one').text(), '');
+        assert.equal(find('.random-one').text(), '');
+    });
+    ajax('/api/lists', 'GET', 200, [{id: 1, name: 'one', reviews: [{rating: 5}, {rating: 5}, {rating: 5}]}, {id: 2, name: 'two', reviews: [{rating: 3}, {rating: 1}]}]);
+    click('.refresh-list:eq(0)');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 2);
+        assert.equal(find('.list-item-one .item-rating').length, 5);
+        assert.equal(find('.list-item-one .item-rating:eq(2)').text(), '5');
+        assert.equal(find('.list-item-two .item-name').length, 2);
+        assert.equal(find('.list-item-two .item-rating').length, 5);
+        assert.equal(find('.list-item-two .item-rating:eq(2)').text(), '5');
+        assert.equal(find('.list-item-three .item-name').length, 2);
+        assert.equal(find('.list-item-three .item-rating').length, 5);
+        assert.notEqual(find('.unrelated-one').text(), '');
+        assert.equal(find('.random-one').text(), '');
+    });
+    click('.random-change:eq(0)');
+    andThen(() => {
+        assert.equal(currentURL(), '/lists');
+        assert.equal(find('.list-item-one .item-name').length, 2);
+        assert.equal(find('.list-item-one .item-rating').length, 5);
+        assert.equal(find('.list-item-two .item-name').length, 2);
+        assert.equal(find('.list-item-two .item-rating').length, 5);
+        assert.equal(find('.list-item-three .item-name').length, 2);
+        assert.equal(find('.list-item-three .item-rating').length, 5);
+        assert.notEqual(find('.unrelated-one').text(), '');
+        assert.notEqual(find('.random-one').text(), '');
+        //each component would render 6x prior
+        assert.equal(oneUpdated, 3);
+        assert.equal(twoUpdated, 3);
+        assert.equal(fourUpdated, 1);
+        assert.equal(fiveUpdated, 1);
+    });
+});

--- a/tests/dummy/app/components/filter-list/component.js
+++ b/tests/dummy/app/components/filter-list/component.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+export default Ember.Component.extend({
+  layout: hbs`
+    <button class="filter-list" onclick={{action filter value}}>filter</button>
+  `
+});

--- a/tests/dummy/app/components/list-html/component.js
+++ b/tests/dummy/app/components/list-html/component.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+export default Ember.Component.extend({
+  layout: hbs`
+    {{#each items as |item|}}
+      <div class="item-name">{{item.name}}</div>
+      {{#each item.reviews as |review|}}
+        <span class="item-rating">{{review.rating}}</span>
+      {{/each}}
+    {{/each}}
+  `
+});

--- a/tests/dummy/app/components/list-one/component.js
+++ b/tests/dummy/app/components/list-one/component.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import ajax from 'dummy/utilities/ajax';
+import hbs from 'htmlbars-inline-precompile';
+import connect from 'ember-redux/components/connect';
+import filterRating from 'dummy/utilities/filter';
+
+var stateToComputed = (state) => {
+  return {
+    items: filterRating(state.list.all, state.list.filter)
+  };
+};
+
+var dispatchToActions = (dispatch) => {
+  return {
+    filter: (filter) => dispatch({type: 'FILTER_LIST', filter: filter}),
+    refresh: () => ajax('/api/lists', 'GET').then(response => dispatch({type: 'TRANSFORM_LIST', response: response})),
+    update: () => dispatch({type: 'UNRELATED_UPDATE'}),
+    random: () => dispatch({type: 'RANDOM_UPDATE'})
+  };
+};
+
+var ListOneComponent = Ember.Component.extend({
+    layout: hbs`
+        {{yield items (action "filter") (action "refresh") (action "update") (action "random")}}
+    ` 
+});
+
+export default connect(stateToComputed, dispatchToActions)(ListOneComponent);

--- a/tests/dummy/app/components/list-two/component.js
+++ b/tests/dummy/app/components/list-two/component.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import connect from 'ember-redux/components/connect';
+import filterRating from 'dummy/utilities/filter';
+
+var stateToComputed = (state) => {
+  return {
+    items: filterRating(state.list.all, state.list.filter),
+    filter: state.list.filter
+  };
+};
+
+var dispatchToActions = (dispatch) => {
+  return {
+    filter: (filter) => dispatch({type: 'FILTER_LIST', filter: filter})
+  };
+};
+
+var ListTwoComponent = Ember.Component.extend({
+    layout: hbs`
+        {{yield items (action "filter")}}
+    ` 
+});
+
+export default connect(stateToComputed, dispatchToActions)(ListTwoComponent);

--- a/tests/dummy/app/components/random-change/component.js
+++ b/tests/dummy/app/components/random-change/component.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+export default Ember.Component.extend({
+  layout: hbs`
+    <button class="random-change" onclick={{action random}}>random</button>
+  `
+});

--- a/tests/dummy/app/components/random-one/component.js
+++ b/tests/dummy/app/components/random-one/component.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import connect from 'ember-redux/components/connect';
+
+var stateToComputed = (state) => {
+  return {
+    random: state.list.random
+  };
+};
+
+var RandomComponent = Ember.Component.extend({
+  layout: hbs`
+    {{yield random}}
+  `
+});
+
+export default connect(stateToComputed)(RandomComponent);

--- a/tests/dummy/app/components/refresh-list/component.js
+++ b/tests/dummy/app/components/refresh-list/component.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+export default Ember.Component.extend({
+  layout: hbs`
+    <button class="refresh-list" onclick={{action refresh}}>refresh</button>
+  `
+});

--- a/tests/dummy/app/components/unrelated-change/component.js
+++ b/tests/dummy/app/components/unrelated-change/component.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+export default Ember.Component.extend({
+  layout: hbs`
+    <button class="unrelated-change" onclick={{action update}}>update</button>
+  `
+});

--- a/tests/dummy/app/components/unrelated-one/component.js
+++ b/tests/dummy/app/components/unrelated-one/component.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import connect from 'ember-redux/components/connect';
+
+var stateToComputed = (state) => {
+  return {
+    unrelated: state.list.unrelated
+  };
+};
+
+var UnrelatedComponent = Ember.Component.extend({
+  layout: hbs`
+    {{yield unrelated}}
+  `
+});
+
+export default connect(stateToComputed)(UnrelatedComponent);

--- a/tests/dummy/app/lists/route.js
+++ b/tests/dummy/app/lists/route.js
@@ -1,0 +1,8 @@
+import ajax from 'dummy/utilities/ajax';
+import route from 'ember-redux/route';
+
+var model = (dispatch) => {
+    return ajax('/api/lists', 'GET').then(response => dispatch({type: 'TRANSFORM_LIST', response: response}));
+};
+
+export default route({model})();

--- a/tests/dummy/app/lists/template.hbs
+++ b/tests/dummy/app/lists/template.hbs
@@ -1,0 +1,34 @@
+<div class="list-item-one">
+  {{#list-one as |items filter|}}
+    {{filter-list filter=filter value="5"}}
+    {{list-html items=items}}
+  {{/list-one}}
+</div>
+
+<div class="list-item-two">
+  {{#list-two as |items filter|}}
+    {{filter-list filter=filter value=""}}
+    {{list-html items=items}}
+  {{/list-two}}
+</div>
+
+<div class="list-item-three">
+  {{#list-one as |items filter refresh update random|}}
+    {{refresh-list refresh=refresh}}
+    {{unrelated-change update=update}}
+    {{random-change random=random}}
+    {{list-html items=items}}
+  {{/list-one}}
+</div>
+
+<div class="unrelated">
+  {{#unrelated-one as |unrelated|}}
+    <span class="unrelated-one">{{unrelated}}</span>
+  {{/unrelated-one}}
+</div>
+
+<div class="random">
+  {{#random-one as |random|}}
+    <span class="random-one">{{random}}</span>
+  {{/random-one}}
+</div>

--- a/tests/dummy/app/reducers/index.js
+++ b/tests/dummy/app/reducers/index.js
@@ -4,6 +4,7 @@ import all from 'dummy/reducers/all';
 import users from 'dummy/reducers/users';
 import roles from 'dummy/reducers/roles';
 import items from 'dummy/reducers/items';
+import list from 'dummy/reducers/list';
 import models from 'dummy/reducers/models';
 
 export default {
@@ -13,5 +14,6 @@ export default {
     users: users,
     roles: roles,
     models: models,
-    items: items
+    items: items,
+    list: list
 };

--- a/tests/dummy/app/reducers/list.js
+++ b/tests/dummy/app/reducers/list.js
@@ -1,0 +1,33 @@
+const initialState = {
+    all: [],
+    filter: null,
+    unrelated: null,
+    random: null
+};
+
+export default ((state, action) => {
+    if (action.type === 'TRANSFORM_LIST') {
+        return Object.assign({}, state, {
+            all: action.response
+        });
+    }
+    if (action.type === 'FILTER_LIST') {
+        return Object.assign({}, state, {
+            filter: action.filter
+        });
+    }
+    if (action.type === 'UNRELATED_UPDATE') {
+        return Object.assign({}, state, {
+            unrelated: `unrelated ... ${Math.random()}`
+        });
+    }
+    if (action.type === 'RANDOM_UPDATE') {
+        return Object.assign({}, state, {
+            random: Math.random(),
+            all: state.all,
+            filter: state.filter,
+            unrelated: state.unrelated
+        });
+    }
+    return state || initialState;
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,7 @@ Router.map(function() {
   this.route('items', function() {
       this.route('detail', {path: '/:item_id'});
   });
+  this.route('lists', { path: '/lists' });
   this.route('fetch', { path: '/fetch' });
   this.route('super', { path: '/super' });
   this.route('thunk', { path: '/thunk' });

--- a/tests/dummy/app/utilities/filter.js
+++ b/tests/dummy/app/utilities/filter.js
@@ -1,0 +1,9 @@
+var average = (item) => {
+    var total = item.reviews.map(r => r.rating).reduce((a, b) => a + b);
+    return total / item.reviews.length;
+};
+
+export default function(items, filter) {
+    var filterBy = parseInt(filter, 10);
+    return filterBy ? items.filter(i => average(i) >= filterBy) : items;
+}

--- a/tests/unit/-private/equal-test.js
+++ b/tests/unit/-private/equal-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import shallowEqual from 'ember-redux/-private/equal';
+
+var result;
+
+module('Unit | Private | Equal');
+
+test('should return true if arguments fields are equal', (assert) => {
+    result = shallowEqual(
+        { a: 1, b: 2, c: undefined },
+        { a: 1, b: 2, c: undefined }
+    );
+    assert.equal(result, true);
+
+    result = shallowEqual(
+        { a: 1, b: 2, c: 3 },
+        { a: 1, b: 2, c: 3 }
+    );
+    assert.equal(result, true);
+
+    const o = {};
+    result = shallowEqual(
+        { a: 1, b: 2, c: o },
+        { a: 1, b: 2, c: o }
+    );
+    assert.equal(result, true);
+
+    const d = function () { return 1; };
+    result = shallowEqual(
+        { a: 1, b: 2, c: o, d: d },
+        { a: 1, b: 2, c: o, d: d }
+    );
+    assert.equal(result, true);
+});
+
+test('should return false if arguments fields are different function identities', (assert) => {
+    result = shallowEqual(
+        { a: 1, b: 2, d: function () { return 1; } },
+        { a: 1, b: 2, d: function () { return 1; } }
+    );
+    assert.equal(result, false);
+});
+
+test('should return false if first argument has too many keys', (assert) => {
+    result = shallowEqual(
+        { a: 1, b: 2, c: 3 },
+        { a: 1, b: 2 }
+    );
+    assert.equal(result, false);
+});
+
+test('should return false if second argument has too many keys', (assert) => {
+    result = shallowEqual(
+        { a: 1, b: 2 },
+        { a: 1, b: 2, c: 3 }
+    );
+    assert.equal(result, false);
+});
+
+test('should return false if arguments have different keys', (assert) => {
+    result = shallowEqual(
+        { a: 1, b: 2, c: undefined },
+        { a: 1, bb: 2, c: undefined }
+    );
+    assert.equal(result, false);
+});


### PR DESCRIPTION
This pull request aims to solve the performance problem that exists today with subscribe. Currently on any change we ask each component to re-render everything (not ideal) so in this PR we only ask for a re-render when state watched locally is truly different.