### PR TITLE
ember-cli upgrade

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,22 +13,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-indent_style = space
-indent_size = 2
-
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,8 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=ember-2.0.X
-  - EMBER_TRY_SCENARIO=ember-2.1.X
-  - EMBER_TRY_SCENARIO=ember-2.2.X
-  - EMBER_TRY_SCENARIO=ember-2.3.X
   - EMBER_TRY_SCENARIO=ember-2.4.X
-  - EMBER_TRY_SCENARIO=ember-2.5.X
-  - EMBER_TRY_SCENARIO=ember-2.6.X
-  - EMBER_TRY_SCENARIO=ember-2.7.X
+  - EMBER_TRY_SCENARIO=ember-2.8.X
   - EMBER_TRY_SCENARIO=ember-beta
 
 before_install:

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,8 @@
 {
   "name": "ember-redux",
   "dependencies": {
-    "ember": "^2.7.0",
-    "ember-cli-shims": "0.1.0",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
+    "ember": "~2.8.0",
+    "ember-cli-shims": "0.1.1",
     "fauxjax-toranb": "1.9.0",
     "jquery": "~2.1.4"
   }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,33 +11,6 @@ module.exports = {
       }
     },
     {
-      name: 'ember-2.1.X',
-      dependencies: {
-        'ember': '~2.1.0'
-      },
-      resolutions: {
-        'ember': '~2.1.0'
-      }
-    },
-    {
-      name: 'ember-2.2.X',
-      dependencies: {
-        'ember': '~2.2.0'
-      },
-      resolutions: {
-        'ember': '~2.2.0'
-      }
-    },
-    {
-      name: 'ember-2.3.X',
-      dependencies: {
-        'ember': '~2.3.0'
-      },
-      resolutions: {
-        'ember': '~2.3.0'
-      }
-    },
-    {
       name: 'ember-2.4.X',
       dependencies: {
         'ember': '~2.4.0'
@@ -47,30 +20,12 @@ module.exports = {
       }
     },
     {
-      name: 'ember-2.5.X',
+      name: 'ember-2.8.X',
       dependencies: {
-        'ember': '~2.5.0'
+        'ember': '~2.8.0'
       },
       resolutions: {
-        'ember': '~2.5.0'
-      }
-    },
-    {
-      name: 'ember-2.6.X',
-      dependencies: {
-        'ember': '~2.6.0'
-      },
-      resolutions: {
-        'ember': '~2.6.0'
-      }
-    },
-    {
-      name: 'ember-2.7.X',
-      dependencies: {
-        'ember': '~2.7.0'
-      },
-      resolutions: {
-        'ember': '~2.7.0'
+        'ember': '~2.8.0'
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -25,23 +25,24 @@
   "author": "Toran Billups toranb@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "ember-cli": "2.4.2",
+    "ember-cli": "2.8.0",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.0",
-    "broccoli-asset-rev": "^2.2.0",
+    "loader.js": "^4.0.1",
+    "broccoli-asset-rev": "^2.4.2",
     "ember-browserify": "^1.1.11",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.1",
-    "ember-cli-release": "0.2.8",
+    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-jshint": "^1.0.0",
+    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-release": "0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-export-application-global": "^1.0.4",
-    "ember-load-initializers": "^0.5.0",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.5.1",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-try": "0.1.3",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"
@@ -54,7 +55,7 @@
     "redux"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -48,6 +48,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -29,7 +29,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +11,13 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
-      }
-
-      destroyApp(this.application);
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,15 +21,14 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     <script type="text/preload" charset="utf-8" preload-roles="roles" data-configuration='[{"id": 2, "name":"Admin"}, {"id": 3, "name":"Guest"}]'></script>
 
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
It was time to upgrade the project from ember-cli 2.4.2 => 2.8.0

Also I noticed we ran nearly every 2x build of ember and I don't think we truly need this anymore. Now we just run 2.0/each LTS and the beta with travis-ci