### PR TITLE
[BUG]: wrap updateProps in Ember.run

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import shallowEqual from '../-private/equal';
 
-const { computed, defineProperty } = Ember;
+const { computed, defineProperty, run } = Ember;
 
 var connect = function(mapStateToComputed, mapDispatchToActions) {
     var shouldSubscribe = Boolean(mapStateToComputed);
@@ -44,13 +44,15 @@ var connect = function(mapStateToComputed, mapDispatchToActions) {
                 this._super(...arguments);
             },
             handleChange() {
-                var redux = this.get('redux');
-                var props = mapState(redux.getState());
-                var componentState = this.getComponentState(props);
-                var reduxState = finalMapStateToComputed(redux.getState());
-                if (!shallowEqual(componentState, reduxState)) {
-                    this.updateProps(props);
-                }
+                run(() => {
+                    var redux = this.get('redux');
+                    var props = mapState(redux.getState());
+                    var componentState = this.getComponentState(props);
+                    var reduxState = finalMapStateToComputed(redux.getState());
+                    if (!shallowEqual(componentState, reduxState)) {
+                        this.updateProps(props);
+                    }
+                });
             },
             getComponentState(props) {
                 var componentState = {};

--- a/tests/acceptance/rerender-test.js
+++ b/tests/acceptance/rerender-test.js
@@ -13,6 +13,23 @@ module('Acceptance | rerender test', {
     }
 });
 
+test('should rerender when state is changed by other redux consumers', function(assert) {
+  const redux = application.__container__.lookup('service:redux');
+  ajax('/api/lists', 'GET', 200, []);
+
+  visit('/lists');
+
+  andThen(() => {
+    assert.equal(find('.list-item-one .item-name').length, 0, "No items initially");
+
+    redux.dispatch({type: 'TRANSFORM_LIST', response: [{id: 1, name: 'bob', reviews: [{rating: 5}]}]});
+
+    andThen(() => {
+      assert.equal(find('.list-item-one .item-name').length, 1, "One item after redux dispatch");
+    });
+  });
+});
+
 test('should only rerender when connected component is listening for each state used to compute', function(assert) {
     ajax('/api/lists', 'GET', 200, [{id: 1, name: 'one', reviews: [{rating: 5}, {rating: 5}]}, {id: 2, name: 'two', reviews: [{rating: 3}, {rating: 1}]}]);
     visit('/lists');


### PR DESCRIPTION
If the redux state is changed by an outsider, acceptance tests can potentially fail as rerender occurs after the test completes.

Wrapping updateProps with Ember.run fixes this.