### PR TITLE
Refactor `connect`

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -1,70 +1,107 @@
 import Ember from 'ember';
 
-const { computed, defineProperty, run } = Ember;
+const {
+    computed: { readOnly },
+    defineProperty,
+    inject: { service },
+    run
+} = Ember;
 
-var connect = function(mapStateToComputed, mapDispatchToActions) {
-    var shouldSubscribe = Boolean(mapStateToComputed);
-    var finalMapStateToComputed = mapStateToComputed || function() {return {};};
-    var finalMapDispatchToActions = mapDispatchToActions || function() {return {};};
+export default function connect(mapStateToComputed = () => ({}), mapDispatchToActions = () => ({})) {
+
     return function wrapWithConnect(WrappedComponent) {
-        var mapState = function(state) {
-            var props = [];
-            Object.keys(finalMapStateToComputed(state)).forEach(function(key) {
-                props.push(key);
-            });
-            return props;
-        };
-        var mapDispatch= function(dispatch) {
-            var actions = [];
-            Object.keys(finalMapDispatchToActions(dispatch)).forEach(function(key) {
+
+        const mapDispatch = function(dispatch) {
+            let actions = [];
+            Object.keys(mapDispatchToActions(dispatch)).forEach(function(key) {
                 actions.push(key);
             });
             return actions;
         };
+
         return WrappedComponent.extend({
-            redux: Ember.inject.service('redux'),
+
+            redux: service(),
+
+            /**
+             * Prepare the wrapped component.
+             *
+             * Get the initial state from redux and compute the desired properties.
+             * Transform the resulting object to private properties that we can
+             * update internally, then create public "read-only" aliases for the
+             * user to use.
+             */
             init() {
-                var component = this;
-                component['actions'] = Ember.$.extend({}, component['actions']);
-                var redux = this.get('redux');
-                var props = mapState(redux.getState());
-                var dispatch = mapDispatch(redux.dispatch.bind(redux));
-                props.forEach(function(name) {
-                    defineProperty(component, name, computed(function() {
-                        return finalMapStateToComputed(redux.getState())[name];
-                    }).property().readOnly());
+                const redux = this.get('redux');
+
+                // Compute and set private properties based on current state
+                const props = this.updateProps(redux.getState());
+
+                // Set public read-only aliases for the private component properties
+                Object.keys(props).forEach(key => {
+                    defineProperty(this, key, readOnly(this.getPrivateKey(key)));
                 });
-                dispatch.forEach(function(action) {
-                    component['actions'][action] = finalMapDispatchToActions(redux.dispatch.bind(redux))[action];
-                });
-                if (shouldSubscribe && !this.unsubscribe) {
-                    this.unsubscribe = redux.subscribe(this.handleChange.bind(this));
+
+                // If we have added properties, subscribe to future updates
+                if (Object.keys(props).length > 0 && !this.unsubscribe) {
+                    this.unsubscribe = redux.subscribe(() => {
+                        run(() => {
+                            this.updateProps(redux.getState());
+                        });
+                    });
                 }
+
+                // Set up actions
+                this['actions'] = Ember.$.extend({}, this['actions']);
+                const dispatch = mapDispatch(redux.dispatch.bind(redux));
+                dispatch.forEach(action => {
+                    this['actions'][action] = mapDispatchToActions(redux.dispatch.bind(redux))[action];
+                });
+
                 this._super(...arguments);
             },
-            handleChange() {
-                run(() => {
-                    var redux = this.get('redux');
-                    var props = mapState(redux.getState());
-                    var componentState = this.getComponentState(props);
-                    var reduxState = finalMapStateToComputed(redux.getState());
-                    props.forEach((name) => {
-                        if (componentState[name] !== reduxState[name]) {
-                            this.updateProps(name);
-                        }
+
+            /**
+             * Transform a key into it's private equivalent by prepending an underscore.
+             */
+            getPrivateKey(key) {
+                return `_${key}`;
+            },
+
+            /**
+             * Transform properties' state into a private component state object.
+             *
+             * Example:
+             *
+             * transformPropsToPrivate({ users: [] }) => { _users: [] }
+             */
+            transformPropsToPrivate(props) {
+                // Transform object to new object with private keys
+                return Object.keys(props).reduce((privateState, key) => {
+                    return Object.assign(privateState, {
+                        [this.getPrivateKey(key)]: props[key]
                     });
-                });
+                }, {});
             },
-            getComponentState(props) {
-                var componentState = {};
-                props.forEach((name) => {
-                    componentState[name] = this.get(name);
-                });
-                return componentState;
+
+            /**
+             * Update the (private) properties with the given state.
+             *
+             * The provided state is run through the user-provided `mapStateToComputed`
+             * function.  The resulting props object is then transformed into its
+             * "private" equavalent and set on the component as private properties.
+             *
+             * Returns the props object.
+             */
+            updateProps(state) {
+                const props = mapStateToComputed(state);
+                this.setProperties(this.transformPropsToPrivate(props));
+                return props;
             },
-            updateProps(name) {
-                this.notifyPropertyChange(name);
-            },
+
+            /**
+             * Unsubscribe from redux updates.
+             */
             willDestroy() {
                 this._super(...arguments);
                 if (this.unsubscribe) {
@@ -74,6 +111,4 @@ var connect = function(mapStateToComputed, mapDispatchToActions) {
             }
         });
     };
-};
-
-export default connect;
+}

--- a/tests/acceptance/rerender-test.js
+++ b/tests/acceptance/rerender-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { test, module } from 'qunit';
 import startApp from '../helpers/start-app';
 
-var application, oneUpdated = 0, twoUpdated = 0, fourUpdated = 0, fiveUpdated = 0;
+var application;
 
 module('Acceptance | rerender test', {
     beforeEach() {
@@ -44,29 +44,6 @@ test('should only rerender when connected component is listening for each state 
         assert.equal(find('.list-item-three .item-rating').length, 4);
         assert.equal(find('.unrelated-one').text(), '');
         assert.equal(find('.random-one').text(), '');
-    });
-    andThen(() => {
-        var componentOne = application.__container__.lookup('component:list-one');
-        var componentTwo = application.__container__.lookup('component:list-two');
-        var componentFour = application.__container__.lookup('component:unrelated-one');
-        var componentFive = application.__container__.lookup('component:random-one');
-        var original = componentOne.updateProps;
-        componentOne.updateProps = function() {
-            oneUpdated = oneUpdated + 1;
-            return original.apply(this, arguments);
-        };
-        componentTwo.updateProps = function() {
-            twoUpdated = twoUpdated + 1;
-            return original.apply(this, arguments);
-        };
-        componentFour.updateProps = function() {
-            fourUpdated = fourUpdated + 1;
-            return original.apply(this, arguments);
-        };
-        componentFive.updateProps = function() {
-            fiveUpdated = fiveUpdated + 1;
-            return original.apply(this, arguments);
-        };
     });
     click('.filter-list:eq(0)');
     andThen(() => {
@@ -154,10 +131,6 @@ test('should only rerender when connected component is listening for each state 
         assert.equal(find('.list-item-three .fake-value').text(), 1);
         assert.notEqual(find('.unrelated-one').text(), '');
         assert.notEqual(find('.random-one').text(), '');
-        assert.equal(oneUpdated, 3);
-        assert.equal(twoUpdated, 4);
-        assert.equal(fourUpdated, 1);
-        assert.equal(fiveUpdated, 1);
     });
     click('.fake-change:eq(0)');
     click('.fake-change:eq(0)');
@@ -175,9 +148,5 @@ test('should only rerender when connected component is listening for each state 
         assert.equal(find('.list-item-three .fake-value').text(), 5);
         assert.notEqual(find('.unrelated-one').text(), '');
         assert.notEqual(find('.random-one').text(), '');
-        assert.equal(oneUpdated, 5);
-        assert.equal(twoUpdated, 4);
-        assert.equal(fourUpdated, 1);
-        assert.equal(fiveUpdated, 1);
     });
 });


### PR DESCRIPTION
This is a different approach to the concerns raised in #30 + some additional refactoring.

Since this is a refactor, it might be easier to reason about by [looking at the new connect.js](https://github.com/dustinfarris/ember-redux/blob/617155000cb42267d081b59e41d2b82f0f51a2bc/addon/components/connect.js) rather than trying to make sense of the diff.

### Using `Ember.Object.setProperties`

This greatly simplifies the code and transfers optimization responsibility to Ember, where it should stay if at all possible.

The properties work like this:

On init (and after every state change via redux.subscribe), the user props are computed using the user-supplied `mapStateToComputed` function.  The resulting object might look like e.g.:

```js
// props
{
  users: [ { id: 1, name: 'Bob' } ]
}
```

The resulting props object is transformed into an equivalent object with "private" keys, e.g.:

```js
// props with private keys
{
  _users: [ { id: 1, name: 'Bob' } ]
}
```

The transformed object is set on the component using setProperties,

```js
this.setProperties(privateProps);
```

"read-only" aliases are set up to match what the user expects

```js
// Simplified
Ember.defineProperty(this, 'user', Ember.computed.readOnly('_user'));
```

This allows us to update the "private" component properties using redux.subscribe, and the user continues to consume the public read-only props (which are just aliases).  It is important to emphasize that _no additional state is being created_—just a pathway that allows us to make updates to the component and still keep everything locked down.

_Note: the `updateProps` counter tests are removed because updateProps now fires on every redux state change, as it should._

### Move logic to component methods

Rather than using behind-the-scenes functions, this PR moves most of the logic to a public API on the WrappedComponent object.  This feels a bit more Emberish to me, and more importantly, allows the user to adjust behavior if desired.

Specifically, these public methods are added (or modified):

- `WrappedComponent.getPrivateKey`
- `WrappedComponent.transformPropsToPrivate`
- `WrappedComponent.updateProps`

Most likely some unit tests are appropriate here.  I can add those, but would like feedback about this change first.  I think it is the right way to go, although we may want to make the methods private at first before committing to API support—and then make them public later on if it makes sense.

### Minor stuff

After discussing with @toranb I took some liberty to swap in ES6 syntax here and there.  Mostly this doesn't change anything, although I did set up default arguments to connect, and moved the logic for `shouldSubscribe` to a check in `init` for a length of props keys > 0.

### Dispatch not touched

Other than the default argument to mapDispatchToActions, I have left the dispatch logic alone.  Depending on how the refactor for properties is received, we may want to refactor dispatch to match the style and spirit _et al_.

## TODO

- [ ] Flesh out comments (we should probably use JSDoc format)
- [ ] Unit tests for WrappedComponent methods
- [ ] Decision to move mapToDispatch to component method

----

cc @brettburley 