### PR TITLE
Update both ember and ember-cli to v2.9.1 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "ember-redux",
   "dependencies": {
-    "ember": "~2.8.0",
-    "ember-cli-shims": "0.1.1",
+    "ember": "~2.9.0",
+    "ember-cli-shims": "0.1.3",
     "fauxjax-toranb": "1.9.0",
     "jquery": "~2.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
   "author": "Toran Billups toranb@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "ember-cli": "2.8.0",
+    "ember-cli": "2.9.1",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.1",
-    "broccoli-asset-rev": "^2.4.2",
+    "loader.js": "^4.0.10",
+    "broccoli-asset-rev": "^2.4.5",
     "ember-browserify": "^1.1.11",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^1.0.4",
+    "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -57,7 +57,7 @@
     "redux"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/utilities/array.js
+++ b/tests/dummy/app/utilities/array.js
@@ -6,7 +6,7 @@ export function uniq(first, second) {
         if (found === -1) {
             ret.push(k);
         }else{
-            ret.replace(found, 1, k);
+            ret.splice(found, 1, k);
         }
     });
     return ret;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -10,6 +10,10 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>


### PR DESCRIPTION
Keeping up with the cool kids - the only huge jump I see is from `ember-cli-qunit v2.1.0 => v3`

This time it's just the bower/package.json/ember-cli updates :)