### PR TITLE
Refactor connect

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -1,69 +1,103 @@
 import Ember from 'ember';
 
-const { computed: { readOnly }, defineProperty, run } = Ember;
+const {
+  computed: { readOnly },
+  defineProperty,
+  inject: { service },
+  isEmpty,
+  run
+} = Ember;
 
-var connect = function(mapStateToComputed, mapDispatchToActions) {
-  var shouldSubscribe = Boolean(mapStateToComputed);
-  var finalMapStateToComputed = mapStateToComputed || function() {return {};};
-  var finalMapDispatchToActions = mapDispatchToActions || function() {return {};};
-  return function wrapWithConnect(WrappedComponent) {
-    var mapState = function(state) {
-      var props = [];
-      Object.keys(finalMapStateToComputed(state)).forEach(function(key) {
-        props.push(key);
-      });
-      return props;
-    };
+/**
+ * Modifies a Component by mapping redux state and dispatch to its properties
+ * and actions respectively.
+ *
+ * ```javascript
+ * const stateToComputed = (state) => {
+ *   return { all: state.all };
+ * }
+ * const dispatchToActions = (dispatch) => {
+ *   return { more: dispatch({ type: 'MORE' }) };
+ * }
+ * const MyComponent = Ember.Component.extend();
+ *
+ * export default connect(MyComponent, stateToComputed, dispatchToActions);
+ * ```
+ *
+ * @function connect
+ * @param {Ember.Component} Component the Ember component to be connected
+ * @param {function} stateToComputed A function that maps redux state to an
+ *   object of desired properties that will be added to the component
+ * @param {function} dispatchToActions A function that maps component
+ *   actions to redux dispatch
+ * @returns {Ember.Component} The original component with mapped properties
+ *   and actions
+ */
+export default function connect(Component, stateToComputed = () => ({}), dispatchToActions = () => ({})) {
 
-    var mapDispatch= function(dispatch) {
-      var actions = [];
-      Object.keys(finalMapDispatchToActions(dispatch)).forEach(function(key) {
-        actions.push(key);
-      });
-      return actions;
-    };
+  return Component.extend({
 
-    return WrappedComponent.extend({
-      redux: Ember.inject.service('redux'),
-      init() {
-        var component = this;
-        component['actions'] = Ember.$.extend({}, component['actions']);
-        var redux = this.get('redux');
-        var props = mapState(redux.getState());
-        var dispatch = mapDispatch(redux.dispatch.bind(redux));
-        // Create a private object to hold private properties
-        this.set('_props', Ember.Object.create());
-        // Compute and set private properties based on current state
-        this.updateProps(redux.getState());
+    redux: service(),
+
+    /**
+     * Prepare the wrapped the component.
+     *
+     * Get the initial state from redux and compute the desired properties.
+     * Store the properties on a private `_props` property, then create
+     * public read-only aliases for the user to use.
+     *
+     * @method init
+     */
+    init() {
+      const redux = this.get('redux');
+
+      // Create an empty private object to hold properties
+      this.set('_props', Ember.Object.create());
+      // Compute and set private properties based on current state
+      let propNames = Object.keys(this.updateProps(redux.getState()));
+      if (!isEmpty(propNames)) {
         // Set public read-only aliases to the private properties
-        props.forEach(function(name) {
-          defineProperty(component, name, readOnly(`_props.${name}`));
+        propNames.forEach(name => {
+          defineProperty(this, name, readOnly(`_props.${name}`));
         });
-        dispatch.forEach(function(action) {
-          component['actions'][action] = finalMapDispatchToActions(redux.dispatch.bind(redux))[action];
-        });
-        if (shouldSubscribe && !this.unsubscribe) {
-          this.unsubscribe = redux.subscribe(() => {
-            run(() => {
-              this.updateProps(redux.getState());
-            });
+        // Subscribe to future updates
+        this.unsubscribe = redux.subscribe(() => {
+          run(() => {
+            this.updateProps(redux.getState());
           });
-        }
-        this._super(...arguments);
-      },
-      updateProps(state) {
-        var props = finalMapStateToComputed(state);
-        this.get('_props').setProperties(props);
-      },
-      willDestroy() {
-        this._super(...arguments);
-        if (this.unsubscribe) {
-          this.unsubscribe();
-          this.unsubscribe = null;
-        }
+        });
       }
-    });
-  };
-};
 
-export default connect;
+      // Set up actions
+      this.actions = Object.assign({},
+        this.actions, dispatchToActions(redux.dispatch.bind(redux))
+      );
+
+      this._super(...arguments);
+    },
+
+    /**
+     * Update the private properties object with the given state.
+     *
+     * The state is run through the user-provided `stateToComputed` function.
+     * The resulting properties are set on the components `_props` property.
+     *
+     * @method updateProps
+     * @param {Object} state the current state of the application (ala redux)
+     * @returns {Object} the properties that were set on the component
+     */
+    updateProps(state) {
+      var props = stateToComputed(state);
+      return this.get('_props').setProperties(props);
+    },
+
+    willDestroy() {
+      this._super(...arguments);
+      // Disconnect the redux subscription, if applicable
+      if (this.unsubscribe) {
+        this.unsubscribe();
+        this.unsubscribe = null;
+      }
+    }
+  });
+}

--- a/tests/dummy/app/components/count-list/component.js
+++ b/tests/dummy/app/components/count-list/component.js
@@ -36,4 +36,4 @@ var CountListComponent = Ember.Component.extend({
   }
 });
 
-export default connect(stateToComputed, dispatchToActions)(CountListComponent);
+export default connect(CountListComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/dashboard-main/component.js
+++ b/tests/dummy/app/components/dashboard-main/component.js
@@ -20,4 +20,4 @@ var DashboardMainComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed, dispatchToActions)(DashboardMainComponent);
+export default connect(DashboardMainComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/empty-thing/component.js
+++ b/tests/dummy/app/components/empty-thing/component.js
@@ -8,4 +8,4 @@ var EmptyThingComponent = Ember.Component.extend({
   `
 });
 
-export default connect()(EmptyThingComponent);
+export default connect(EmptyThingComponent);

--- a/tests/dummy/app/components/fetch-users/component.js
+++ b/tests/dummy/app/components/fetch-users/component.js
@@ -27,4 +27,4 @@ var UserListComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed, dispatchToActions)(UserListComponent);
+export default connect(UserListComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/item-detail/component.js
+++ b/tests/dummy/app/components/item-detail/component.js
@@ -20,4 +20,4 @@ var ItemDetailComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed, dispatchToActions)(ItemDetailComponent);
+export default connect(ItemDetailComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/item-list/component.js
+++ b/tests/dummy/app/components/item-list/component.js
@@ -20,4 +20,4 @@ var ItemListComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed)(ItemListComponent);
+export default connect(ItemListComponent, stateToComputed);

--- a/tests/dummy/app/components/list-one/component.js
+++ b/tests/dummy/app/components/list-one/component.js
@@ -27,4 +27,4 @@ var ListOneComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed, dispatchToActions)(ListOneComponent);
+export default connect(ListOneComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/list-two/component.js
+++ b/tests/dummy/app/components/list-two/component.js
@@ -22,4 +22,4 @@ var ListTwoComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed, dispatchToActions)(ListTwoComponent);
+export default connect(ListTwoComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/random-one/component.js
+++ b/tests/dummy/app/components/random-one/component.js
@@ -14,4 +14,4 @@ var RandomComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed)(RandomComponent);
+export default connect(RandomComponent, stateToComputed);

--- a/tests/dummy/app/components/saga-counter/component.js
+++ b/tests/dummy/app/components/saga-counter/component.js
@@ -21,4 +21,4 @@ var SagaComponent = Ember.Component.extend({
     `
 });
 
-export default connect(stateToComputed, dispatchToActions)(SagaComponent);
+export default connect(SagaComponent, stateToComputed, dispatchToActions);

--- a/tests/dummy/app/components/unrelated-one/component.js
+++ b/tests/dummy/app/components/unrelated-one/component.js
@@ -14,4 +14,4 @@ var UnrelatedComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed)(UnrelatedComponent);
+export default connect(UnrelatedComponent, stateToComputed);

--- a/tests/dummy/app/components/user-detail/component.js
+++ b/tests/dummy/app/components/user-detail/component.js
@@ -14,4 +14,4 @@ var UserDetailComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed)(UserDetailComponent);
+export default connect(UserDetailComponent, stateToComputed);

--- a/tests/dummy/app/components/user-list/component.js
+++ b/tests/dummy/app/components/user-list/component.js
@@ -18,4 +18,4 @@ var UserListComponent = Ember.Component.extend({
   `
 });
 
-export default connect(stateToComputed)(UserListComponent);
+export default connect(UserListComponent, stateToComputed);

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -60,7 +60,7 @@ test('each computed is truly readonly', function(assert) {
 
 test('lifecycle hooks are still invoked', function(assert) {
   assert.expect(2);
-  this.register('component:test-component', connect()(Ember.Component.extend({
+  this.register('component:test-component', connect(Ember.Component.extend({
     init() {
       assert.ok(true, 'init is invoked');
       this._super(...arguments);


### PR DESCRIPTION
This is a **BREAKING CHANGE**

Simplifies `connect` by leveraging ES6 syntax and accepting `Component` as a primary argument.  This usage is more straight-forward and is easier to reason about internally.

Usage becomes, e.g.:

```js
const stateToComputed = (state) => {
  return { all: state.all };
}

const dispatchToActions = (dispatch) => {
  return { more: dispatch({ type: 'MORE' }) };
}

const MyComponent = Ember.Component.extend();

export default connect(MyComponent, stateToComputed, dispatchToActions);
```
