### PR TITLE
[PERFORMANCE]: avoid multiple redux.getState() calls in connect

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -45,22 +45,13 @@ var connect = function(mapStateToComputed, mapDispatchToActions) {
       handleChange() {
         run(() => {
           var redux = this.get('redux');
-          var props = mapState(redux.getState());
-          var componentState = this.getComponentState(props);
           var reduxState = finalMapStateToComputed(redux.getState());
-          props.forEach((name) => {
-            if (componentState[name] !== reduxState[name]) {
+          Object.keys(reduxState).forEach((name) => {
+            if (this.get(name) !== reduxState[name]) {
               this.notifyPropertyChange(name);
             }
           });
         });
-      },
-      getComponentState(props) {
-        var componentState = {};
-        props.forEach((name) => {
-          componentState[name] = this.get(name);
-        });
-        return componentState;
       },
       willDestroy() {
         this._super(...arguments);


### PR DESCRIPTION
I've simplified the callback workload to reduce the number of times we invoke redux.getState() in handleChange from 2x to 1x and also I've eliminated an unnecessary function (used previously in the shallowEqual days of connect). My hope is that we can achieve the same goal #41 set out to solve but without the tradeoff of holding state local in the component (and further -helping us avoid Ember.set / setProperties).

After the over notify problem was solved, the remaining "Problem Statement" back in #30 was that we call redux.getState() multiple times during re-render work and that could be expensive. This PR should solve a good chunk of that and I'm asking @dbashford to confirm we didn't break his app. In addition, I'm reaching out to @justinpark to confirm he won't run into a performance issue of any kind taking this new connect implementation.

Would you both have time this week to try out this updated connect function and report back?