### PR TITLE
[REFACTOR]: remove Ember.K in favor of () => {}

### DIFF
--- a/app/services/redux.js
+++ b/app/services/redux.js
@@ -5,7 +5,7 @@ import enhancers from '../enhancers/index';
 import optional from '../reducers/optional';
 import middlewareConfig from '../middleware/index';
 
-const { assert, isArray, K } = Ember;
+const { assert, isArray } = Ember;
 
 // Handle "classic" middleware exports (i.e. an array), as well as the hash option
 const extractMiddlewareConfig = (mc) => {
@@ -17,7 +17,7 @@ const extractMiddlewareConfig = (mc) => {
 }
 
 // Destructure the middleware array and the setup thunk into two different variables
-const { middleware, setup = K } = extractMiddlewareConfig(middlewareConfig);
+const { middleware, setup = () => {} } = extractMiddlewareConfig(middlewareConfig);
 
 var { createStore, applyMiddleware, combineReducers, compose } = redux;
 var createStoreWithMiddleware = compose(applyMiddleware(...middleware), enhancers)(createStore);


### PR DESCRIPTION
The way things look today it's very possible Ember.K will be deprecated

https://github.com/cibernox/rfcs/blob/738bd4c646ed679693ef733f99e1a10ab93242af/text/0000-deprecate-ember-k.md

This simply helps us be proactive instead of reactive - also the more vanillaJS the better :)

