### PR TITLE
[FEATURE] pass attrs to stateToComputed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
 import ajax from 'example/utilities/ajax';
+import getUsersByAccountId from '../reducers';
 
-var stateToComputed = (state) => {
+var stateToComputed = (state, attrs) => {
   return {
-    users: state.users.all
+    users: getUsersByAccountId(state, attrs.accountId)
   };
 };
 
@@ -73,7 +74,7 @@ export default UserTableComponent;
 
 ## Example Composition
 ```js
-{{#user-list as |users remove|}}
+{{#user-list accountId=accountId as |users remove|}}
   {{user-table users=users remove=remove}}
 {{/user-list}}
 ```

--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -19,11 +19,11 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
       init() {
         const redux = this.get('redux');
 
-        let props = stateToComputed(redux.getState());
+        let props = stateToComputed(redux.getState(), this.getAttrs());
 
         Object.keys(props).forEach(name => {
           defineProperty(this, name, computed(() =>
-            stateToComputed(redux.getState())[name]
+            stateToComputed(redux.getState(), this.getAttrs())[name]
           ).property().readOnly());
         });
 
@@ -43,13 +43,40 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
       handleChange() {
         const redux = this.get('redux');
 
-        let props = stateToComputed(redux.getState());
+        let props = stateToComputed(redux.getState(), this.getAttrs());
 
         Object.keys(props).forEach(name => {
           if (this.get(name) !== props[name]) {
             this.notifyPropertyChange(name);
           }
         });
+      },
+
+      /**
+       * Return an object of attrs passed to this Component.
+       *
+       * `Component.attrs` is an object that can look like this:
+       *
+       *   {
+       *     myAttr: {
+       *       value: 'myValue'
+       *     }
+       *   }
+       *
+       * Ember provides that a `get` will return the value:
+       *
+       *   this.get('myAttr') === 'myValue'
+       *
+       * @method getAttrs
+       * @private
+       */
+      getAttrs() {
+        return this.getProperties(Object.keys(this.attrs || {}));
+      },
+
+      didUpdateAttrs() {
+        this._super(...arguments);
+        this.handleChange();
       },
 
       willDestroy() {

--- a/tests/dummy/app/components/count-list/component.js
+++ b/tests/dummy/app/components/count-list/component.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
 
-var stateToComputed = (state) => {
+var stateToComputed = (state, attrs) => {
   return {
     low: state.low,
-    high: state.high
+    high: state.high,
+    greeting: `Welcome back, ${attrs.name}!`
   };
 };
 
@@ -24,6 +25,7 @@ var CountListComponent = Ember.Component.extend({
     <button class="btn-random" onclick={{action "random"}}>random</button>
     <button class="btn-alter" onclick={{action "alter"}}>alter</button>
     <span class="random-state">{{color}}</span>
+    <span class="greeting">{{greeting}}</span>
   `,
   actions: {
     alter() {

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -38,6 +38,18 @@ test('should render parent component with one state and child component with ano
   assert.equal($child.text(), 7);
 });
 
+test('should render attrs', function(assert) {
+  assert.expect(2);
+  this.set('myName', 'Dustin');
+  this.render(hbs`{{count-list name=myName}}`);
+
+  assert.equal(this.$('.greeting').text(), 'Welcome back, Dustin!', 'should render attrs provided to component');
+
+  this.set('myName', 'Toran');
+
+  assert.equal(this.$('.greeting').text(), 'Welcome back, Toran!', 'should rerender component if attrs change');
+});
+
 test('the component should truly be extended meaning actions map over as you would expect', function(assert) {
   this.render(hbs`{{count-list}}`);
   let $random = this.$('.random-state');
@@ -59,10 +71,15 @@ test('each computed is truly readonly', function(assert) {
 });
 
 test('lifecycle hooks are still invoked', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
   this.register('component:test-component', connect()(Ember.Component.extend({
     init() {
       assert.ok(true, 'init is invoked');
+      this._super(...arguments);
+    },
+
+    didUpdateAttrs() {
+      assert.ok(true, 'didUpdateAttrs should be invoked');
       this._super(...arguments);
     },
 
@@ -72,5 +89,7 @@ test('lifecycle hooks are still invoked', function(assert) {
     }
   })));
 
-  this.render(hbs`{{test-component}}`);
+  this.render(hbs`{{test-component name=name}}`);
+
+  this.set('name', 'Dustin');
 });


### PR DESCRIPTION
### Summary

This adds a second argument to `stateToComputed` that contains an object with the attrs that were passed to a component.

E.g.:

```hbs
{{my-component userId=userId}}
```

```js
stateToComputed = (state, attrs) => {
  return { user: getUserById(state, attrs.userId) };
}
```

This is analogous to [the same API in react-redux](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options).


### Details

As suggested by @wooandoo in #54, rather than pass `this.attrs` and leave it at that, a new object is computed that alleviates the need to crawl through the intermediary attr.  This object is cached for performance and only updated if the inbound attrs change as signaled by `didUpdateAttrs`.  More details can be found in the included docstring for `computeAndCacheAttrs()`.


### Also

react-redux does the same thing for `mapDispatchToProps`, however this is not so easy in Ember.  It seems that after actions are defined, they cannot be easily redefined—therefore the action would not update if the attrs changed, as the user would expect.  This PR leaves `dispatchToActions` alone until this can be investigated further.


### Alternative

Rather than putting together an attrs object, we could just pass the entire component itself, e.g.:

```js
// connect.js
...
let props = stateToComputed(redux.getState(), this);
```

```hbs
{{my-component userId=userId}}
```

```js
stateToComputed = (state, component) => {
  return { user: getUserById(state, component.get('userId')) };
}
```

This would provide a lot more flexibility and simplify the internal implementation, however it would be a little out of step with react-redux, and opens the door for possible misuse.

/cc @toranb 