### PR TITLE
Drop browserify

### DIFF
--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -1,4 +1,4 @@
-import thunk from 'npm:redux-thunk';
+import thunk from 'redux-thunk';
 
 var resolved = thunk.default ? thunk.default : thunk;
 

--- a/app/services/redux.js
+++ b/app/services/redux.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import redux from 'npm:redux';
+import redux from 'redux';
 import reducers from '../reducers/index';
 import enhancers from '../enhancers/index';
 import optional from '../reducers/optional';

--- a/blueprints/ember-redux/index.js
+++ b/blueprints/ember-redux/index.js
@@ -4,15 +4,9 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addAddonsToProject({
-      packages: [
-        {name: 'ember-browserify', target: '^1.1.11'},
-      ]
-    }).then(function() {
-      return this.addPackagesToProject([
-        {name: 'redux', target: '^3.5.2'},
-        {name: 'redux-thunk', target: '^2.1.0'}
-      ]);
-    }.bind(this));
+    return this.addPackagesToProject([
+      {name: 'redux', target: '^3.5.2'},
+      {name: 'redux-thunk', target: '^2.1.0'}
+    ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,41 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+var mergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
-  name: 'ember-redux'
+  name: 'ember-redux',
+
+  included: function(app) {
+    // Import UMD redux and redux-thunk
+    // transform to named AMD that we can import
+    app.import('vendor/redux.js', {
+      using: [{ transformation: 'amd', as: 'redux' }]
+    });
+    app.import('vendor/redux-thunk.js', {
+      using: [{ transformation: 'amd', as: 'redux-thunk' }]
+    });
+    // If developing the addon itself, add redux-saga
+    if (this.parent.pkg.name === 'ember-redux') {
+      app.import('vendor/redux-saga.js', {
+        using: [{ transformation: 'amd', as: 'redux-saga' }]
+      });
+    }
+  },
+
+  treeForVendor: function() {
+    // Grab the UMD distributions of redux and redux-thunk
+    var trees = [
+      path.join(path.dirname(require.resolve('redux')), '..', 'dist'),
+      path.join(path.dirname(require.resolve('redux-thunk')), '..', 'dist'),
+    ];
+    // If developing the addon itself, add redux-saga
+    if (this.parent.pkg.name === 'ember-redux') {
+      trees.push(
+        path.join(path.dirname(require.resolve('redux-saga')), '..', 'dist')
+      );
+    }
+    return mergeTrees(trees);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-browserify": "^1.1.11",
     "ember-cli": "2.9.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -57,7 +56,12 @@
     "redux"
   ],
   "dependencies": {
+    "broccoli-merge-trees": "^1.1.5",
     "ember-cli-babel": "^5.1.7"
+  },
+  "peerDependencies": {
+    "redux": "^3.5.2",
+    "redux-thunk": "^2.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/sagas/counter.js
+++ b/tests/dummy/app/sagas/counter.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
-import saga from 'npm:redux-saga';
-import effects from 'npm:redux-saga/effects';
+import { effects, takeEvery } from 'redux-saga';
 
-const { takeEvery } = saga;
 const { call, put } = effects;
 
 const delay = ms => Ember.run.next(resolve => setTimeout(resolve, ms));

--- a/tests/helpers/patch-middleware.js
+++ b/tests/helpers/patch-middleware.js
@@ -1,4 +1,5 @@
-define('dummy/middleware/index', ['exports', 'ember', 'npm:redux-saga', 'dummy/sagas/counter'], function (exports, _ember, _npmReduxSaga, _dummySagasCounter) {
+define('dummy/middleware/index', ['exports', 'ember', 'redux-saga', 'dummy/sagas/counter'], function (exports, _ember, _npmReduxSaga, _dummySagasCounter) {
+
   var createSaga = _npmReduxSaga['default']['default'] ? _npmReduxSaga['default']['default'] : _npmReduxSaga['default'];
 
   var sagaMiddleware = createSaga();


### PR DESCRIPTION
## Summary

Use the UMD distributions of redux and redux-thunk instead of browserifying the CJS source.

This relies on the new [transformation feature](https://github.com/ember-cli/ember-cli/pull/5976) for `app.import` available in ember-cli 2.9.0.


## Details

The dependencies are added to the vendor tree via `treeForVendor` which resolves their path and adds the appropriate dist folder containing the UMD files.  Then files are then imported into the project using the AMD transformation flag and given the appropriate package name ("redux" and "redux-thunk").

If the build is for addon development, redux-saga is also added.

redux and redux-thunk are installed and added to the users dependencies via the default blueprint.  ember-redux adds redux and redux-thunk as peerDependencies to maintain control over supported versions.  _As an alternative_, this could be done as a regular ember-redux dependency, which would mean we could skip the blueprint altogether.  However, peerDependencies gives the user finer control over the precise version of redux and redux-thunk they want to use.


## Considerations

- Are we ok with having the user continue to explicitly install redux and redux-thunk?  (automated by the default blueprint and enforced by package.json peerDependencies)
- We remain Ember 2.0.X compatible, but the user must be using ember-cli >= 2.9

----

/cc @aaminev @MiguelMadero