### PR TITLE
[BUG] stateToComputed and Ember binding

### DIFF
--- a/tests/acceptance/connect-e2e-test.js
+++ b/tests/acceptance/connect-e2e-test.js
@@ -70,3 +70,15 @@ test('components without state should not subscribe or unsubscribe', function(as
     assert.equal(unsubscribed, 1);
   });
 });
+
+
+test('binding computed props does not affect redux state', function(assert) {
+  visit('/project');
+  assert.deepEqual(redux.getState().project, { name: 'Chores' });
+
+  fillIn('.project-name', 'Todos');
+
+  andThen(() => {
+    assert.deepEqual(redux.getState().project, { name: 'Chores' }, 'state should not be affected by Ember binding');
+  });
+});

--- a/tests/dummy/app/components/project-detail/component.js
+++ b/tests/dummy/app/components/project-detail/component.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import connect from 'ember-redux/components/connect';
+
+const { Component } = Ember;
+
+const stateToComputed = state => {
+  return {
+    project: state.project
+  };
+};
+
+const ProjectDetailComponent = Component.extend({
+  layout: hbs`
+  {{project-edit project=project}}
+  `
+});
+
+export default connect(stateToComputed)(ProjectDetailComponent);

--- a/tests/dummy/app/components/project-edit/component.js
+++ b/tests/dummy/app/components/project-edit/component.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  layout: hbs`
+  <input class="project-name" value={{project.name}} oninput={{action (mut project.name) value="target.value"}}>
+  `
+});

--- a/tests/dummy/app/project/template.hbs
+++ b/tests/dummy/app/project/template.hbs
@@ -1,0 +1,1 @@
+{{project-detail}}

--- a/tests/dummy/app/reducers/index.js
+++ b/tests/dummy/app/reducers/index.js
@@ -6,6 +6,7 @@ import roles from 'dummy/reducers/roles';
 import items from 'dummy/reducers/items';
 import list from 'dummy/reducers/list';
 import models from 'dummy/reducers/models';
+import project from 'dummy/reducers/project';
 
 export default {
   low: low,
@@ -15,5 +16,6 @@ export default {
   roles: roles,
   models: models,
   items: items,
-  list: list
+  list: list,
+  project: project
 };

--- a/tests/dummy/app/reducers/project.js
+++ b/tests/dummy/app/reducers/project.js
@@ -1,0 +1,10 @@
+const initialState = {
+  name: 'Chores'
+};
+
+export default (state=initialState, action) => { // jshint ignore:line
+  if (action.type === 'UPDATE_PROJECT') {
+    return Object.assign(state, action.data);
+  }
+  return state;
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -22,6 +22,7 @@ Router.map(function() {
   this.route('super', { path: '/super' });
   this.route('thunk', { path: '/thunk' });
   this.route('simple', { path: '/simple' });
+  this.route('project', { path: '/project' });
 });
 
 export default Router;


### PR DESCRIPTION
## Summary

Passing objects from redux state to other components results in Ember binding which affects the state itself.  This affects the purity/immutability of redux, and has the potential be problematic in practice especially if the user is unaware that this is happening.


## Details

Let's say current redux.getState() looks like this:

```
redux.getState();

{
  project: {
    name: 'Chores'
  }
}
```

And you have a "container" component that looks like this:

```js
const stateToComputed = (state) => {
  return {
    project: state.project
  }
}

const ProjectContainerComponent = Component.extend({
  layout: hbs`{{project-detail project=project}}`
});
```

As soon as you pass the computed property, `project`, to another component, Ember "binds" it so it can watch for changes.  Because this is all passed down by reference, the transformation that Ember performs to accomplish this go all the way back to redux state!

Now, your redux state looks something like this (depending on which browser you're using to inspect):

```
redux.getState();

{
  project: {
    __ember_meta__: { ... }
    getter: ...
    setter: ...
    name: 'Chores'
  }
}
```

The failing test in this PR shows one example of how this can bite you:

- The project-container component invokes the project-presentation component and binds the `project` computed property as provided by stateToComputed
- The test attempts a dispatch that updates the project in redux state, `dispatch({ type: 'UPDATE_PROJECT', newData: { name: 'New Name' } })`
- The dispatch handler attempts `Object.assign(state, newData)` which results in an error

```
You must use Ember.set() to set the `name` property (of [object Object])
```


## Solution

In the computed, we could deep copy stateToComputed before peeling off the desired property:

```js
// connect.js

defineProperty(this, name, computed(() =>
  Ember.$.extend(true, {}, stateToComputed(redux.getState()))[name]
).property().readOnly());
```

## Alternative

Do nothing.  Even though Ember modifies the state in this way, it may be possible to work with it nonetheless.  For example, with Object.assign, prepending and empty object works:

```js
Object.assign({}, boundState, newObject);  // works
Object.assign(boundState, newObject);  // throws error
```

Users can also deep copy on their own on a case-by-case basis:

```js
stateToComputed = (state) => {
  return {
    project: Ember.$.extend(true, {}, state.project)
  };
};
```

This could potentially get very expensive, and the user would need to know about this nuance of Ember, and how to deal with it.  Documentation would probably be appropriate.