### PR TITLE
Coalesce changes in handleChange

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -5,7 +5,9 @@ const {
   defineProperty,
   inject: { service },
   isEmpty,
-  run
+  run,
+  beginPropertyChanges,
+  endPropertyChanges
 } = Ember;
 
 export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
@@ -45,11 +47,13 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
 
         let props = stateToComputed(redux.getState(), this.getAttrs());
 
+        beginPropertyChanges();
         Object.keys(props).forEach(name => {
           if (this.get(name) !== props[name]) {
             this.notifyPropertyChange(name);
           }
         });
+        endPropertyChanges();
       },
 
       /**


### PR DESCRIPTION
By wrapping the changes in `beginPropertyChanges` and `endPropertyChanges`, we should be able to achieve the same performance wins as using `setProperties` (https://github.com/emberjs/ember.js/blob/v2.10.0/packages/ember-metal/lib/set_properties.js#L5-L7). A caveat: {begin,end}PropertyChanges are private methods.