### PR TITLE
API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /bower_components
 
 # misc
+/out
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
 import ajax from 'example/utilities/ajax';
-import getUsersByAccountId from '../reducers';
 
 var stateToComputed = (state, attrs) => {
   return {
-    users: getUsersByAccountId(state, attrs.accountId)
+    users: state.users.all
   };
 };
 
@@ -74,7 +73,7 @@ export default UserTableComponent;
 
 ## Example Composition
 ```js
-{{#user-list accountId=accountId as |users remove|}}
+{{#user-list as |users remove|}}
   {{user-table users=users remove=remove}}
 {{/user-list}}
 ```
@@ -97,6 +96,12 @@ export default redux.compose(devtools);
     npm install
     bower install
     ember test
+
+
+## Building API docs
+
+    npm docs
+
 
 ## License
 

--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 
+/**
+ * @module ember-redux/components
+ */
+
 const {
   computed,
   defineProperty,
@@ -8,6 +12,110 @@ const {
   run
 } = Ember;
 
+/**
+ * Return an object of properties to be added to the Ember Component.
+ *
+ * If this is specified, the component will subscribe to Redux store updates.
+ * Any time it updates, `stateToComputed` will be called.
+ *
+ * The first argument is the current state.  If `attrs` is specified as the
+ * second argument, its value will be the current attrs that were passed to
+ * your component.
+ *
+ * For example, if the component is invoked like so:
+ *
+ * ```handlebars
+ * {{item-detail itemId=123}}
+ * ```
+ *
+ * Then the value of the `attrs` argument will be `{ itemId: 123 }`.
+ *
+ * You can use that to retrieve the part of state you need, for example:
+ *
+ * ```javascript
+ * import getItemById from '../reducers';
+ *
+ * const stateToComputed = (state, attrs) => {
+ *   return {
+ *     item: getItemById(state, attrs.itemId)
+ *   };
+ * };
+ * ```
+ *
+ * `stateToComputed` will be re-evaluated any time the attrs or the
+ * state change.
+ *
+ * @callback stateToComputed
+ * @param {Object} [state] - the current Redux state
+ * @param {Object} [attrs] - attrs that were passed to the Ember Component
+ * @returns {Object} the desired properties to be added to the Component
+ */
+
+/**
+ * Return an object of actions to be added to the Ember Component.
+ *
+ * The actions provided by this function will be merged with any existing
+ * actions the Component already has.
+ *
+ * For example, if you want to set up an action to delete an item:
+ *
+ * ```javascript
+ * const dispatchToActions = (dispatch) => {
+ *   return {
+ *     delete(item) { dispatch({ type: 'DELETE_ITEM', item }) }
+ *   };
+ * };
+ * ```
+ *
+ * @callback dispatchToActions
+ * @param {function} [dispatch] - Redux dispatch
+ * @returns {Object} the desired actions to be added to the Component
+ */
+
+/**
+ * Connect an Ember component to a Redux store.
+ *
+ * It does not modify the component class passed to it.  Instead, it returns a
+ * new, connected component class for you to use.
+ *
+ * ```javascript
+ * // components/all-items.js
+ *
+ * import connect from 'ember-redux/components/connect';
+ *
+ * const stateToComputed = (state, attrs) => {
+ *   return { allItems: state.items.all };
+ * };
+ * const dispatchToActions = (dispatch) => {
+ *   return {
+ *     delete(item) { dispatch({ type: 'DELETE_ITEM', item }) }
+ *   };
+ * };
+ * const AllItemsComponent = Ember.Component.extend({
+ *   layout: hbs`
+ *     <ul>
+ *       {{#each allItems as |item|}}
+ *         <li>
+ *           <h3>{{item.name}}</h3>
+ *           <button {{action "delete" item}}>Remove</button>
+ *         </li>
+ *       {{/each}}
+ *     </ul>
+ *   `
+ * });
+ *
+ * export default connect(stateToComputed, dispatchToActions)(ItemsComponent);
+ * ```
+ *
+ * @function connect
+ * @param {function} [stateToComputed] - a function that maps redux state and
+ *   component attrs to an object of desired properties that will be added to
+ *   the component
+ * @param {function} [dispatchToActions] - a function that maps component actions
+ *   to redux dispatch calls
+ * @returns {function} a new function that accepts an Ember Component and
+ *   returns it with mapped properties and actions
+ */
 export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
 
   return Component => {
@@ -16,6 +124,15 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
 
       redux: service(),
 
+      /**
+       * Prepare the connected component.
+       *
+       * Get the inital state from Redux and compute the desired properties and
+       * actions.  If there are properties to add, subscribe to the Redux store
+       * for future updates.
+       *
+       * @method init
+       */
       init() {
         const redux = this.get('redux');
 
@@ -40,6 +157,12 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
         this._super(...arguments);
       },
 
+      /**
+       * Re-evaluate `stateToComputed` and notify changes (if any).
+       *
+       * @method handleChange
+       * @private
+       */
       handleChange() {
         const redux = this.get('redux');
 
@@ -57,15 +180,19 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
        *
        * `Component.attrs` is an object that can look like this:
        *
-       *   {
-       *     myAttr: {
-       *       value: 'myValue'
-       *     }
+       * ```javascript
+       * {
+       *   myAttr: {
+       *     value: 'myValue'
        *   }
+       * }
+       * ```
        *
        * Ember provides that a `get` will return the value:
        *
-       *   this.get('myAttr') === 'myValue'
+       * ```javascript
+       * this.get('myAttr') === 'myValue'
+       * ```
        *
        * @method getAttrs
        * @private
@@ -74,11 +201,17 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
         return this.getProperties(Object.keys(this.attrs || {}));
       },
 
+      /**
+       * Re-evaluate if attrs for this Component change.
+       */
       didUpdateAttrs() {
         this._super(...arguments);
         this.handleChange();
       },
 
+      /**
+       * Unsubscribe from the Redux store.
+       */
       willDestroy() {
         this._super(...arguments);
         if (this.unsubscribe) {

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["plugins/markdown"]
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "scripts": {
+    "docs": "jsdoc addon -r -c jsdoc.conf.json",
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:testall"
@@ -44,6 +45,7 @@
     "ember-maybe-import-regenerator": "0.1.4",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.1.3",
+    "jsdoc": "^3.4.3",
     "loader.js": "^4.0.10",
     "redux": "^3.5.2",
     "redux-saga": "0.12.0",


### PR DESCRIPTION
**WORK IN PROGRESS**

## Summary

This is a first stab at API documentation.


## Details

To get the ball rolling, I've filled out docstrings in connect, but want feedback on what our exact strategy is going to be in terms of hosting.  I looked at yuidoc first, but it is heavily biased to classes.  So I went with good-ol [JSDoc](http://usejsdoc.org/index.html) which is working well.

You can use a new npm command to build the docs:

```
npm docs
```

They will be available in the out/ directory which has been added to gitignore.


## Considerations

- Where do we host this?  How do we automate deployment?
- How does this work with the current ember-redux.com site?
- Due to the function-returning-a-function-returning-a-function implementation for connect, JSDoc does not pick up the inner docstrings for the connected component.  This is probably ok since that code should be considered private anyway.


## Alternative

We could instead add a new API.md file to the gh-pages branch.