### PR TITLE
Allow `null` stateToComputed argument

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -8,7 +8,11 @@ const {
   run
 } = Ember;
 
-export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
+export default (stateToComputed, dispatchToActions=() => ({})) => {
+
+  if (!stateToComputed) {
+    stateToComputed = () => ({});
+  }
 
   return Component => {
 

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -93,3 +93,25 @@ test('lifecycle hooks are still invoked', function(assert) {
 
   this.set('name', 'Dustin');
 });
+
+test('connecting dispatchToActions only', function(assert) {
+  assert.expect(2);
+  const dispatchToActions = () => {};
+
+  this.register('component:test-component-1', connect(null, dispatchToActions)(Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+      assert.ok(true, 'should be able to connect components passing `null` to stateToComputed');
+    }
+  })));
+
+  this.register('component:test-component-2', connect(undefined, dispatchToActions)(Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+      assert.ok(true, 'should be able to connect components passing `undefined` to stateToComputed');
+    }
+  })));
+
+  this.render(hbs`{{test-component-1}}`);
+  this.render(hbs`{{test-component-2}}`);
+});


### PR DESCRIPTION
This restores the ability to pass `null` for `stateToComputed` when connecting a component.