### PR TITLE
Use rollup

### DIFF
--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -1,4 +1,4 @@
-import thunk from 'npm:redux-thunk';
+import thunk from 'redux-thunk';
 
 var resolved = thunk.default ? thunk.default : thunk;
 

--- a/app/services/redux.js
+++ b/app/services/redux.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import redux from 'npm:redux';
+import redux from 'redux';
 import reducers from '../reducers/index';
 import enhancers from '../enhancers/index';
 import optional from '../reducers/optional';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,44 @@
 /* jshint node: true */
 'use strict';
 
+var Rollup = require('broccoli-rollup');
+var path = require('path');
+var nodeResolve = require('rollup-plugin-node-resolve');
+var commonjs = require('rollup-plugin-commonjs');
+var replace = require('rollup-plugin-replace');
+var merge = require('broccoli-merge-trees');
+
 module.exports = {
-  name: 'ember-redux'
+  name: 'ember-redux',
+
+  included: function() {
+    this.app.import('vendor/redux.js');
+    this.app.import('vendor/redux-thunk.js');
+    if (this.app.env === 'test') {
+      this.app.import('vendor/redux-saga.js');
+    }
+  },
+
+  treeForVendor: function() {
+    var runtimeDepTrees = ['redux', 'redux-thunk', 'redux-saga'].map(function(dep) {
+      return new Rollup(path.dirname(require.resolve(dep + '/package.json')), {
+        rollup: {
+          entry: require(dep + '/package.json')['jsnext:main'],
+          targets: [{
+            dest: dep + '.js',
+            format: 'amd',
+            moduleId: dep
+          }],
+          plugins: [
+            nodeResolve(),
+            commonjs(),
+            replace({
+              'process.env.NODE_ENV': JSON.stringify('production')
+            })
+          ]
+        }
+      });
+    });
+    return merge(runtimeDepTrees);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -57,7 +57,12 @@
     "redux"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "broccoli-merge-trees": "^1.2.1",
+    "broccoli-rollup": "^1.0.3",
+    "ember-cli-babel": "^5.1.7",
+    "rollup-plugin-commonjs": "^5.0.5",
+    "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-replace": "^1.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/sagas/counter.js
+++ b/tests/dummy/app/sagas/counter.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
-import saga from 'npm:redux-saga';
-import effects from 'npm:redux-saga/effects';
+import { effects, takeEvery } from 'redux-saga';
 
-const { takeEvery } = saga;
 const { call, put } = effects;
 
 const delay = ms => Ember.run.next(resolve => setTimeout(resolve, ms));

--- a/tests/helpers/patch-middleware.js
+++ b/tests/helpers/patch-middleware.js
@@ -1,4 +1,4 @@
-define('dummy/middleware/index', ['exports', 'ember', 'npm:redux-saga', 'dummy/sagas/counter'], function (exports, _ember, _npmReduxSaga, _dummySagasCounter) {
+define('dummy/middleware/index', ['exports', 'ember', 'redux-saga', 'dummy/sagas/counter'], function (exports, _ember, _npmReduxSaga, _dummySagasCounter) {
   var createSaga = _npmReduxSaga['default']['default'] ? _npmReduxSaga['default']['default'] : _npmReduxSaga['default'];
 
   var sagaMiddleware = createSaga();


### PR DESCRIPTION
Drop browserify and use rollup to bring in ES6 deps.

See #57 for additional context.

This isn't ready to merge yet, just a proof-of-concept.