### PR TITLE
Reduce the number of run loops created when state changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+
+# vscode
+jsconfig.json
+typings

--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -33,7 +33,7 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
 
         if (!isEmpty(Object.keys(props))) {
           this.unsubscribe = redux.subscribe(() => {
-            run(() => this.handleChange());
+            this.handleChange();
           });
         }
 
@@ -47,13 +47,17 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
       handleChange() {
         const redux = this.get('redux');
 
-        let props = stateToComputed(redux.getState(), this.getAttrs());
+        const props = stateToComputed(redux.getState(), this.getAttrs());
 
-        Object.keys(props).forEach(name => {
-          if (this.get(name) !== props[name]) {
-            this.notifyPropertyChange(name);
-          }
+        const notifyProperties = Object.keys(props).filter(name => {
+          return this.get(name) !== props[name];
         });
+
+        if (notifyProperties.length > 0) {
+          run.join(() => {
+            notifyProperties.forEach(name => this.notifyPropertyChange(name));
+          });
+        }
       },
 
       /**

--- a/tests/integration/runloop-test.js
+++ b/tests/integration/runloop-test.js
@@ -34,17 +34,17 @@ test('handleChange is invoked inside runloop explicitly', function(assert) {
   assert.equal($parent.text(), 1);
 });
 
-// test('handleChange will join an existing runloop when exists', function(assert) {
-//   this.render(hbs`{{count-list}}`);
+test('handleChange will join an existing runloop when exists', function(assert) {
+  this.render(hbs`{{count-list}}`);
 
-//   let $parent = this.$('.parent-state');
+  let $parent = this.$('.parent-state');
 
-//   assert.equal($parent.text(), 0);
+  assert.equal($parent.text(), 0);
 
-//   Ember.run(() => {
-//     this.redux.dispatch({type: 'UP'});
-//   });
+  Ember.run(() => {
+    this.redux.dispatch({type: 'UP'});
+  });
 
-//   assert.equal($parent.text(), 1);
-//   assert.equal(joined, true);
-// });
+  assert.equal($parent.text(), 1);
+  assert.equal(joined, true);
+});


### PR DESCRIPTION
This fixes #64 

Starting with `2.10`, we've begun having issues with excessive and spammy `run` usage (and not just with ember-redux).

The `run(() => this.handleChange())` in particular was causing us problems.  In a relatively small app with 7-10 components getting 4 or 5 quick state updates in succession, we were hitting that `run` 50+ times in a short period of time. With `2.10` that consistently gave us an [`infinite rendering invalidation detected`](https://github.com/emberjs/ember.js/blob/855363285dc66ece8eac9f417375bd4d69460e7e/packages/ember-glimmer/lib/renderer.js#L156) error.

There isn't a lot of information about that particular error, and the Ember code is a bit obtuse, but based on a lot of experimentation the past few days it seems closely related to excessive run loop creation. This PR aims to curb that.

The following is a `console.log` of the`notifyProperties` for a group of components after a button click kicked off a series of redux actions. Every time there is an empty array, that's one `run` avoided.

![image](https://cloud.githubusercontent.com/assets/581127/21198943/5a170994-c20f-11e6-81d7-fb4243ca6450.png)

Even if this weren't a solution to a specific problem we are having, it seems a decent perf improvement. No need to involve Ember run loops if there's nothing to do in the end?

I tried altering this PR code to use [`run.join`](http://emberjs.com/api/classes/Ember.run.html#method_join) rather than `run` as it feels like that would further aid in not creating new run loops. It was successful in my app. But a rerender test broke requiring [a dispatch](https://github.com/toranb/ember-redux/blob/e924d0a6adafeed339272aee9857319c3a01ff62/tests/acceptance/rerender-test.js#L25)  be wrapped in a `run` to pass. Decided to leave that out.